### PR TITLE
downgrade EC2 instance type to nano

### DIFF
--- a/terraform-environments/aws/dev/eks/main.tf
+++ b/terraform-environments/aws/dev/eks/main.tf
@@ -65,7 +65,7 @@ module "eks" {
       max_size     = 10
       desired_size = 1
 
-      instance_types = ["t3.large"]
+      instance_types = ["t2.nano"]
       capacity_type  = "SPOT"
     }
   }


### PR DESCRIPTION
The AWS bill is getting large...the setup started with a large EC2 instance and should be as low as possible.  Based on the current use of this cluster and [this AWS documentation](https://aws.amazon.com/ec2/instance-types/), the cluster will go to t2.nano which is the smallest.