### PR TITLE
Bugfix: Change t2 to t3 instance

### DIFF
--- a/terraform-environments/aws/dev/eks/main.tf
+++ b/terraform-environments/aws/dev/eks/main.tf
@@ -65,7 +65,7 @@ module "eks" {
       max_size     = 10
       desired_size = 1
 
-      instance_types = ["t2.nano"]
+      instance_types = ["t3.nano"]
       capacity_type  = "SPOT"
     }
   }


### PR DESCRIPTION
Update back to T3 from T2 instance.  1.  Its not available in the zones I chose, and 2. it seems to be more expensive than the T3 instances...