### PR TITLE
downgrade instance to t4g.nano

### DIFF
--- a/terraform-environments/aws/dev/eks/main.tf
+++ b/terraform-environments/aws/dev/eks/main.tf
@@ -60,12 +60,12 @@ module "eks" {
   }
 
   eks_managed_node_groups = {
-    example = {
+    dev = {
       min_size     = 1
       max_size     = 10
       desired_size = 1
 
-      instance_types = ["t3.nano"]
+      instance_types = ["t4g.nano"]
       capacity_type  = "SPOT"
     }
   }


### PR DESCRIPTION
- [x] Can be downgraded further, still, from t3.nano to t4g.nano.
- [ ] Try to register for a prepaid plan before applying, unless it needs to be done after.
- [x] Rename the node instance...it is currently named "example".
- [ ] Check for options with the default instance types for managed node groups in the terraform module.
    - [ ] Research a change to the payment type, or make a new ticket if its going to take a bit more work.